### PR TITLE
added mask based energy to wfcos

### DIFF
--- a/mmdet/models/detectors/single_stage.py
+++ b/mmdet/models/detectors/single_stage.py
@@ -64,10 +64,11 @@ class SingleStageDetector(BaseDetector):
                       img_metas,
                       gt_bboxes,
                       gt_labels,
+                      gt_masks =None,
                       gt_bboxes_ignore=None):
         x = self.extract_feat(img)
         outs = self.bbox_head(x)
-        loss_inputs = outs + (gt_bboxes, gt_labels, img_metas, self.train_cfg)
+        loss_inputs = outs + (gt_bboxes, gt_labels,gt_masks, img_metas, self.train_cfg)
         losses = self.bbox_head.loss(
             *loss_inputs, gt_bboxes_ignore=gt_bboxes_ignore)
         self.last_vals = dict(img=img)

--- a/mmdet/ops/tenergy/__init__.py
+++ b/mmdet/ops/tenergy/__init__.py
@@ -1,0 +1,2 @@
+from .tenergy import tenergy_naive
+__all__ = ['tenergy_naive']

--- a/mmdet/ops/tenergy/check.py
+++ b/mmdet/ops/tenergy/check.py
@@ -1,0 +1,30 @@
+import os.path as osp
+import sys
+
+import mmcv
+import torch
+
+sys.path.append(osp.abspath(osp.join(__file__, '../../')))
+from tenergy import tenergy_naive  
+
+
+
+mask = torch.randn(
+    2, 100, 6, 6, requires_grad=False, device='cuda:0').sigmoid().double()
+
+
+masks = torch.randn(
+    2, 25, 200, 200, requires_grad=False, device='cuda:0').sigmoid().float()
+
+time_n= 0
+
+timer = mmcv.Timer()
+
+x = tenergy_naive(masks.clone(),1, 60)
+torch.cuda.synchronize()
+time_n += timer.since_last_check()
+
+print('\TENERGY time: {} ms/iter'.format(
+    (time_n + 1e-3) ))
+
+

--- a/mmdet/ops/tenergy/setup.py
+++ b/mmdet/ops/tenergy/setup.py
@@ -1,0 +1,22 @@
+from setuptools import setup
+
+from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+
+NVCC_ARGS = [
+    '-D__CUDA_NO_HALF_OPERATORS__',
+    '-D__CUDA_NO_HALF_CONVERSIONS__',
+    '-D__CUDA_NO_HALF2_OPERATORS__',
+]
+
+setup(
+    name='tenergy',
+    ext_modules=[
+        CUDAExtension(
+            'tenergy_cuda',
+            ['src/tenergy_cuda.cpp', 'src/tenergy_cuda_kernel.cu'],
+            extra_compile_args={
+                'cxx': [],
+                'nvcc': NVCC_ARGS
+            })
+    ],
+    cmdclass={'build_ext': BuildExtension})

--- a/mmdet/ops/tenergy/src/tenergy_cuda.cpp
+++ b/mmdet/ops/tenergy/src/tenergy_cuda.cpp
@@ -1,0 +1,41 @@
+#include <ATen/ATen.h>
+#include <torch/torch.h>
+
+#include <cmath>
+#include <vector>
+
+int TENERGYLaucher(const at::Tensor masks, const int batch_size,
+                        const int scale_factor,const int max_energy,
+                        const int height, const int width, const int channels,
+                        at::Tensor output);
+
+#define CHECK_CUDA(x) AT_CHECK(x.type().is_cuda(), #x, " must be a CUDAtensor ")
+#define CHECK_CONTIGUOUS(x) \
+  AT_CHECK(x.is_contiguous(), #x, " must be contiguous ")
+#define CHECK_INPUT(x) \
+  CHECK_CUDA(x);       \
+  CHECK_CONTIGUOUS(x)
+
+int tenergy_cuda(at::Tensor masks, int scale_factor, int max_energy,
+                              at::Tensor output) {
+
+  CHECK_INPUT(masks);
+  CHECK_INPUT(output);
+  at::DeviceGuard guard(masks.device());
+
+  int batch_size = output.size(0);
+  int num_channels = output.size(1);
+  int data_height = output.size(2);
+  int data_width = output.size(3);
+
+  TENERGYLaucher(masks,batch_size, scale_factor,max_energy,
+                        data_height, data_width, num_channels,output);
+
+  return 1;
+}
+
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("vote", &tenergy_cuda, "tenery_computation (CUDA)");
+  
+}

--- a/mmdet/ops/tenergy/src/tenergy_cuda_kernel.cu
+++ b/mmdet/ops/tenergy/src/tenergy_cuda_kernel.cu
@@ -1,0 +1,99 @@
+#include <ATen/ATen.h>
+#include <THC/THCAtomics.cuh>
+
+using namespace at;  // temporal fix for pytorch<=0.4.1 (see #9848)
+
+#define THREADS_PER_BLOCK 1024
+
+inline int GET_BLOCKS(const int N) {
+  int optimal_block_num = (N + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
+  int max_block_num = 65536;
+  return min(optimal_block_num, max_block_num);
+}
+
+__device__ inline int Loc2IndexSimple(const int h,const int w, 
+                                const int height, const int width) {
+  int index = h * width + w;
+  return index;
+}
+
+__device__ inline int Loc2Index(const int n, const int c, const int h,
+                                const int w, const int channel_num,
+                                const int height, const int width) {
+  int index = w + (h + (c + n * channel_num) * height) * width;
+  return index;
+}
+
+template <typename scalar_t>
+__global__ void TENERGY(const scalar_t *bottom_masks,
+                                   const int scale_factor, const int k,
+                                   const int height, const int width,const int channels,
+                                   scalar_t *top_data) {
+  
+    int index = blockIdx.x * blockDim.x + threadIdx.x;
+    int pw = index % width;
+    int ph = (index / width) % height;
+    int c = (index / width / height) % channels;
+    int n = index / width / height / channels;
+
+    int mask_index_a =
+              Loc2Index(n,c, ph, pw, channels, height, width);
+    int mask_index_n1 =
+              Loc2Index(n,c, ph + 1, pw,channels,height, width);
+    int mask_index_n2 =
+          Loc2Index(n,c, ph - 1, pw,channels,height, width);
+    int mask_index_n3 =
+          Loc2Index(n,c, ph, pw + 1,channels,height, width);
+    int mask_index_n4 =
+          Loc2Index(n,c, ph, pw - 1,channels,height, width);
+    int mask_index_n5 =
+          Loc2Index(n,c, ph + 1, pw,channels,height, width);
+    int mask_index_n6 =
+          Loc2Index(n,c, ph - 1, pw,channels,height, width);
+    int mask_index_n7 =
+          Loc2Index(n,c, ph, pw + 1,channels,height, width);
+    int mask_index_n8 =
+          Loc2Index(n,c, ph, pw - 1,channels,height, width);
+
+    if(k==0)
+      top_data[mask_index_a] =  bottom_masks[mask_index_a];
+    else if (pw > 0 && ph > 0 && pw < width -1 && ph < height -1)
+    {
+
+        if (top_data[mask_index_n1]>=k && top_data[mask_index_n2]>=k
+          && top_data[mask_index_n3]>=k && top_data[mask_index_n4]>=k
+          && top_data[mask_index_n5]>=k && top_data[mask_index_n6]>=k
+          && top_data[mask_index_n7]>=k && top_data[mask_index_n8]>=k)
+          {
+            top_data[mask_index_a] = top_data[mask_index_a] + 1.0;
+          }
+    }
+}
+
+int TENERGYLaucher(const at::Tensor masks, const int batch_size,
+                              const int scale_factor,const int max_energy,
+                              const int height,const int width, const int channels,
+                              at::Tensor output) {
+  const int output_size = batch_size * channels * height * width;
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+      masks.type(), "TENERGYLaucherVote", ([&] {
+        const scalar_t *bottom_masks = masks.data<scalar_t>();
+        scalar_t *top_data = output.data<scalar_t>();
+        for( int k = 0;k < max_energy; k++)
+        {
+        TENERGY<scalar_t>
+            <<<GET_BLOCKS(output_size), THREADS_PER_BLOCK>>>(
+                bottom_masks, scale_factor, k, height, width, channels, top_data);
+                cudaDeviceSynchronize();
+        }
+      }));
+
+  cudaError_t err = cudaGetLastError();
+  if (cudaSuccess != err) {
+    fprintf(stderr, "cudaCheckError() failed : %s\n", cudaGetErrorString(err));
+    exit(-1);
+  }
+
+  return 1;
+}
+

--- a/mmdet/ops/tenergy/tenergy.py
+++ b/mmdet/ops/tenergy/tenergy.py
@@ -1,0 +1,41 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from mmcv.cnn import normal_init, xavier_init
+from torch.autograd import Function
+from torch.nn.modules.module import Module
+
+from . import tenergy_cuda
+#import tenergy_cuda
+
+class TENERGYFunction(Function):
+
+    @staticmethod
+    def forward(ctx, masks, scale_factor, max_energy):
+        assert scale_factor >= 1
+        assert max_energy  > 1
+    
+        ctx.scale_factor = scale_factor
+        ctx.mask_size = masks.size()
+
+        n, c, h, w = masks.size()
+        output = masks.new_zeros((n, c, h * scale_factor, w * scale_factor))
+        if masks.is_cuda:
+            tenergy_cuda.vote(masks,scale_factor, max_energy, output)
+        else:
+            raise NotImplementedError
+
+
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        assert grad_output.is_cuda
+
+        return None
+
+tenergy_naive = TENERGYFunction.apply
+
+
+
+

--- a/setup.py
+++ b/setup.py
@@ -294,6 +294,13 @@ if __name__ == '__main__':
                 sources=[
                     'src/carafe_naive_cuda.cpp',
                     'src/carafe_naive_cuda_kernel.cu'
+                ]),
+            make_cuda_ext(
+                name='tenergy_cuda',
+                module='mmdet.ops.tenergy',
+                sources=[
+                    'src/tenergy_cuda.cpp',
+                    'src/tenergy_cuda_kernel.cu'
                 ])
         ],
         cmdclass={'build_ext': BuildExtension},


### PR DESCRIPTION
Hi 
Please have a look at wfcos_head.py; I adopted also the label mask, wich can easely uncommented. I also neede to "hack" the single_stage.py to feed instance mask! Please notice the normalization part in "energy_transorm_external" in wfcos_head.py. You need to run setup.py in base folder to compile the cuda part ("tenergy").